### PR TITLE
add rendering of error hint

### DIFF
--- a/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
+++ b/modules/codegen/src/smithy4s/codegen/internals/Renderer.scala
@@ -577,7 +577,7 @@ private[internals] class Renderer(compilationUnit: CompilationUnit) { self =>
     else
       lines(
         line"override val errorable: $option[$Errorable_[$errorName]] = $some(this)",
-        line"val error: $unionSchema_[$errorName] = $errorName.schema",
+        line"val error: $unionSchema_[$errorName] = $errorName.schema.addHints(smithy4s.internals.InputOutput.Error.widen).asInstanceOf[$unionSchema_[$errorName]]",
         block(
           line"def liftError(throwable: Throwable): $option[$errorName] = throwable match"
         ) {

--- a/modules/example/src/smithy4s/example/NameCollision.scala
+++ b/modules/example/src/smithy4s/example/NameCollision.scala
@@ -75,7 +75,7 @@ object NameCollisionGen extends Service.Mixin[NameCollisionGen, NameCollisionOpe
     val hints: Hints = Hints.empty
     def wrap(input: Unit) = MyOp()
     override val errorable: Option[Errorable[MyOpError]] = Some(this)
-    val error: UnionSchema[MyOpError] = MyOpError.schema
+    val error: UnionSchema[MyOpError] = MyOpError.schema.addHints(smithy4s.internals.InputOutput.Error.widen).asInstanceOf[UnionSchema[MyOpError]]
     def liftError(throwable: Throwable): Option[MyOpError] = throwable match {
       case e: smithy4s.example.MyOpError => Some(MyOpError.MyOpErrorCase(e))
       case _ => None

--- a/modules/example/src/smithy4s/example/ObjectService.scala
+++ b/modules/example/src/smithy4s/example/ObjectService.scala
@@ -84,7 +84,7 @@ object ObjectServiceGen extends Service.Mixin[ObjectServiceGen, ObjectServiceOpe
     )
     def wrap(input: PutObjectInput) = PutObject(input)
     override val errorable: Option[Errorable[PutObjectError]] = Some(this)
-    val error: UnionSchema[PutObjectError] = PutObjectError.schema
+    val error: UnionSchema[PutObjectError] = PutObjectError.schema.addHints(smithy4s.internals.InputOutput.Error.widen).asInstanceOf[UnionSchema[PutObjectError]]
     def liftError(throwable: Throwable): Option[PutObjectError] = throwable match {
       case e: ServerError => Some(PutObjectError.ServerErrorCase(e))
       case e: NoMoreSpace => Some(PutObjectError.NoMoreSpaceCase(e))
@@ -141,7 +141,7 @@ object ObjectServiceGen extends Service.Mixin[ObjectServiceGen, ObjectServiceOpe
     )
     def wrap(input: GetObjectInput) = GetObject(input)
     override val errorable: Option[Errorable[GetObjectError]] = Some(this)
-    val error: UnionSchema[GetObjectError] = GetObjectError.schema
+    val error: UnionSchema[GetObjectError] = GetObjectError.schema.addHints(smithy4s.internals.InputOutput.Error.widen).asInstanceOf[UnionSchema[GetObjectError]]
     def liftError(throwable: Throwable): Option[GetObjectError] = throwable match {
       case e: ServerError => Some(GetObjectError.ServerErrorCase(e))
       case _ => None

--- a/modules/example/src/smithy4s/example/imp/ImportService.scala
+++ b/modules/example/src/smithy4s/example/imp/ImportService.scala
@@ -81,7 +81,7 @@ object ImportServiceGen extends Service.Mixin[ImportServiceGen, ImportServiceOpe
     )
     def wrap(input: Unit) = ImportOperation()
     override val errorable: Option[Errorable[ImportOperationError]] = Some(this)
-    val error: UnionSchema[ImportOperationError] = ImportOperationError.schema
+    val error: UnionSchema[ImportOperationError] = ImportOperationError.schema.addHints(smithy4s.internals.InputOutput.Error.widen).asInstanceOf[UnionSchema[ImportOperationError]]
     def liftError(throwable: Throwable): Option[ImportOperationError] = throwable match {
       case e: NotFoundError => Some(ImportOperationError.NotFoundErrorCase(e))
       case _ => None


### PR DESCRIPTION
Posting to ask a question: what should be done here about the type inference? `.addHints` returns a `Schema` rather than what we need here which is a union `Schema`. I can imagine several ways to remedy this, but they would all break bincompat so I want to ask prior to moving forward. The `asInstanceOf` is just there to showcase the issue.